### PR TITLE
Add support for JavaScript templates

### DIFF
--- a/src/utils/templates.js
+++ b/src/utils/templates.js
@@ -1,10 +1,17 @@
 /**
  * Template Utilities
- * Provides support for Jinja2 templates in action configurations.
+ * Provides support for Jinja2 templates and JavaScript templates in action configurations.
  * Enables dynamic values based on Home Assistant state.
  *
- * Templates are rendered via Home Assistant's render_template WebSocket API.
- * Any string containing {{ or {% will be processed as a template.
+ * Jinja2 Templates:
+ * - Syntax: {{ }} or {% %}
+ * - Rendered via Home Assistant's render_template WebSocket API (async)
+ * - Access to HA backend state
+ *
+ * JavaScript Templates:
+ * - Syntax: [[[ ]]]
+ * - Evaluated client-side in browser (sync)
+ * - Access to frontend state including user info (hass.user)
  */
 
 import { logDebug } from './debug.js';
@@ -12,11 +19,82 @@ import { logDebug } from './debug.js';
 /**
  * Check if a string contains Jinja2 template syntax
  * @param {string} value - Value to check
+ * @returns {boolean} True if contains Jinja2 template syntax
+ */
+export function containsJinjaTemplate(value) {
+  if (typeof value !== 'string') return false;
+  return value.includes('{{') || value.includes('{%');
+}
+
+/**
+ * Check if a string contains JavaScript template syntax [[[...]]]
+ * @param {string} value - Value to check
+ * @returns {boolean} True if contains JS template syntax
+ */
+export function containsJsTemplate(value) {
+  if (typeof value !== 'string') return false;
+  return /\[{3}[\s\S]*\]{3}/.test(value);
+}
+
+/**
+ * Check if a string contains any template syntax (Jinja2 or JavaScript)
+ * @param {string} value - Value to check
  * @returns {boolean} True if contains template syntax
  */
 export function containsTemplate(value) {
   if (typeof value !== 'string') return false;
-  return value.includes('{{') || value.includes('{%');
+  return containsJinjaTemplate(value) || containsJsTemplate(value);
+}
+
+/**
+ * Evaluate a JavaScript template [[[ ... ]]]
+ * Executes the code inside the brackets with access to HA context
+ *
+ * Available variables in template:
+ * - states: Home Assistant states object
+ * - user: Current user info (id, name, is_admin, etc.)
+ * - hass: Full Home Assistant object
+ * - entity: Entity state object (if provided)
+ *
+ * @param {Object} hass - Home Assistant object
+ * @param {string} template - Template string with [[[ ... ]]] syntax
+ * @param {Object|null} entity - Optional entity state object
+ * @returns {*} Result of template evaluation
+ */
+export function evalJsTemplate(hass, template, entity = null) {
+  if (!containsJsTemplate(template)) {
+    return template;
+  }
+
+  // Extract code from [[[ ... ]]]
+  const trimmed = template.trim();
+  const match = trimmed.match(/^\[{3}([\s\S]*)\]{3}$/);
+
+  if (!match) {
+    return template;
+  }
+
+  const code = match[1];
+
+  try {
+    /* eslint-disable no-new-func */
+    const result = new Function(
+      'states',
+      'entity',
+      'user',
+      'hass',
+      `'use strict'; ${code}`
+    )(hass.states, entity, hass.user, hass);
+    /* eslint-enable no-new-func */
+
+    logDebug('ACTION', 'JS Template evaluated:', template.substring(0, 50) + '...', '->', result);
+    return result;
+  } catch (e) {
+    const templatePreview = template.length <= 100 ? template.trim() : `${template.trim().substring(0, 98)}...`;
+    logDebug('ERROR', `JS Template error in '${templatePreview}':`, e.message);
+    console.error('ActionsCard JS Template Error:', e);
+    return template; // Return original on error
+  }
 }
 
 /**
@@ -27,7 +105,7 @@ export function containsTemplate(value) {
  * @returns {Promise<string>} Rendered template result
  */
 export async function renderTemplate(hass, template, timeout = 5000) {
-  if (!containsTemplate(template)) {
+  if (!containsJinjaTemplate(template)) {
     return template;
   }
 
@@ -37,7 +115,7 @@ export async function renderTemplate(hass, template, timeout = 5000) {
   }
 
   try {
-    return await new Promise((resolve, reject) => {
+    return await new Promise((resolve, _reject) => {
       let unsubscribe = null;
       let resolved = false;
 
@@ -110,6 +188,7 @@ export async function renderTemplate(hass, template, timeout = 5000) {
 
 /**
  * Check if an object contains any template strings (recursive)
+ * Checks for both Jinja2 and JavaScript templates
  * @param {*} obj - Value to check
  * @returns {boolean} True if templates found
  */
@@ -132,14 +211,22 @@ export function objectContainsTemplates(obj) {
 /**
  * Process all template values in any value recursively
  * Handles strings, arrays, and objects
+ * Supports both Jinja2 (async) and JavaScript (sync) templates
+ *
  * @param {Object} hass - Home Assistant object
  * @param {*} value - Value to process
+ * @param {Object|null} entity - Optional entity state for JS templates
  * @returns {Promise<*>} Value with all templates resolved
  */
-export async function processTemplates(hass, value) {
-  // Handle strings - render if template
+export async function processTemplates(hass, value, entity = null) {
+  // Handle strings - check template type and render appropriately
   if (typeof value === 'string') {
-    if (containsTemplate(value)) {
+    // Check for JS template first (synchronous evaluation)
+    if (containsJsTemplate(value)) {
+      return evalJsTemplate(hass, value, entity);
+    }
+    // Then check for Jinja2 template (async evaluation)
+    if (containsJinjaTemplate(value)) {
       return renderTemplate(hass, value);
     }
     return value;
@@ -147,7 +234,7 @@ export async function processTemplates(hass, value) {
 
   // Handle arrays - process each item
   if (Array.isArray(value)) {
-    const results = await Promise.all(value.map((item) => processTemplates(hass, item)));
+    const results = await Promise.all(value.map((item) => processTemplates(hass, item, entity)));
     return results;
   }
 
@@ -155,7 +242,7 @@ export async function processTemplates(hass, value) {
   if (value && typeof value === 'object') {
     const result = {};
     for (const [key, val] of Object.entries(value)) {
-      result[key] = await processTemplates(hass, val);
+      result[key] = await processTemplates(hass, val, entity);
     }
     return result;
   }


### PR DESCRIPTION
This PR adds Adds support for JavaScript templates in addition to Jinja2. JavaScript templates are evaluated on the frontend, allowing access to front-end only contexts such as the current user's context (user).

Example:

```
- type: custom:actions-card
  card: ...
  ...
  tap_action:
    action: navigate
    navigation_path: |
      [[[
        if (user.id === "...") {
          return "/url-2";
        }
        return "/url-1";
      ]]]
```

This resolves the feature request #9.